### PR TITLE
[Backport] Move buttons definition to separate file

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/adapter.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/adapter.js
@@ -9,8 +9,8 @@ define([
 ], function ($, _, buttons) {
     'use strict';
 
-    var selectorPrefix = '';
-    var eventPrefix;
+    var selectorPrefix = '',
+        eventPrefix;
 
     /**
      * Initialize listener.

--- a/app/code/Magento/Ui/view/base/web/js/form/adapter.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/adapter.js
@@ -5,7 +5,7 @@
 define([
     'jquery',
     'underscore'
-    './adapter/buttons'
+    'Magento_Ui/js/form/adapter/buttons'
 ], function ($, _, buttons) {
     'use strict';
 

--- a/app/code/Magento/Ui/view/base/web/js/form/adapter.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/adapter.js
@@ -9,8 +9,8 @@ define([
 ], function ($, _, buttons) {
     'use strict';
 
-    var selectorPrefix = '',
-        eventPrefix;
+    var selectorPrefix = '';
+    var eventPrefix;
 
     /**
      * Initialize listener.

--- a/app/code/Magento/Ui/view/base/web/js/form/adapter.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/adapter.js
@@ -4,7 +4,7 @@
  */
 define([
     'jquery',
-    'underscore'
+    'underscore',
     'Magento_Ui/js/form/adapter/buttons'
 ], function ($, _, buttons) {
     'use strict';

--- a/app/code/Magento/Ui/view/base/web/js/form/adapter.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/adapter.js
@@ -5,15 +5,11 @@
 define([
     'jquery',
     'underscore'
-], function ($, _) {
+    './adapter/buttons'
+], function ($, _, buttons) {
     'use strict';
 
-    var buttons = {
-            'reset':            '#reset',
-            'save':             '#save',
-            'saveAndContinue':  '#save_and_continue'
-        },
-        selectorPrefix = '',
+    var selectorPrefix = '',
         eventPrefix;
 
     /**

--- a/app/code/Magento/Ui/view/base/web/js/form/adapter/buttons.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/adapter/buttons.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * @api
+ */
+define(function () {
+    return {
+        'reset': '#reset',
+        'save': '#save',
+        'saveAndContinue': '#save_and_continue'
+    }
+});

--- a/app/code/Magento/Ui/view/base/web/js/form/adapter/buttons.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/adapter/buttons.js
@@ -13,5 +13,5 @@ define(function () {
         'reset': '#reset',
         'save': '#save',
         'saveAndContinue': '#save_and_continue'
-    }
+    };
 });

--- a/app/code/Magento/Ui/view/base/web/js/form/adapter/buttons.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/adapter/buttons.js
@@ -7,6 +7,8 @@
  * @api
  */
 define(function () {
+    'use strict';
+
     return {
         'reset': '#reset',
         'save': '#save',


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15194
When trying to add new buttons with new actions (besides `reset`, `save` and `saveAndContinue`) to a UiComponent form in the backend, it is needed to extend upon at least 2 files: `Magento_Ui/js/form/adapter` and `Magento_Ui/js/form/form`. The second file is easily extendable using mixins, but the first one is not: Mainly because the `buttons` definition is based on a local variable. This PR fixes this by moving the `buttons` definition in a separate file.

### Description
This PR adds a new file `buttons.js` that is called for in `adapter` so that someone could create a mixin like follows:

RequireJS configuration:
```js
var config = {
    config: {
        mixins: {
            'Magento_Ui/js/form/form': {
                'Foo_Bar/js/form/form-mixin': true
            }
        }
    }
};
```
And in `Foo_Bar/js/form/form-mixin`:
```js
define([
    'underscore'
], function (_) {
    'use strict';

    var mixin = {
        'foobar': '#foobar'
    };

    return function (target) {
        return _.extend(target, mixin);
    };
});
```
Unfortunately, this PR does not deal with how to use `foobar` in the end, which is hugely complex.

### Manual testing scenarios
1. Apply the PR
2. Confirm that form buttons like `Save` and `Save And Continue` are still working in the backend

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
